### PR TITLE
Feature/actions output label

### DIFF
--- a/lua/actions/executor/run_action.lua
+++ b/lua/actions/executor/run_action.lua
@@ -72,7 +72,7 @@ function run.run(action, on_exit)
   ---@return boolean
   local function run_steps_recursively(steps)
     if next(steps) == nil then
-      run.clean(action, true, on_exit)
+      run.clean(action, true, on_exit, -1)
       return false
     end
     ---@type Step: a step to be run as a job
@@ -153,7 +153,7 @@ function run.run(action, on_exit)
           end
         end
         if next(s) ~= nil and run.write_output(path, s) == false then
-          run.clean(action, true, on_exit)
+          run.clean(action, true, on_exit, -1)
         end
       end,
       on_stdout = function(_, d)
@@ -169,7 +169,7 @@ function run.run(action, on_exit)
           end
         end
         if next(s) ~= nil and run.write_output(path, s) == false then
-          run.clean(action, true, on_exit)
+          run.clean(action, true, on_exit, -1)
         end
       end,
       on_exit = function(_, code)
@@ -182,7 +182,7 @@ function run.run(action, on_exit)
               .. "exited with code: "
               .. code,
           })
-          run.clean(action, true, on_exit)
+          run.clean(action, true, on_exit, code)
           return
         end
         if next(steps) ~= nil then
@@ -192,7 +192,7 @@ function run.run(action, on_exit)
           path,
           { "", "> ACTION [" .. action.name .. "] SUCCESS" }
         )
-        run.clean(action, true, on_exit)
+        run.clean(action, true, on_exit, code)
       end,
     })
     if ok == true then
@@ -200,7 +200,7 @@ function run.run(action, on_exit)
       return true
     end
     log.warn(started_job)
-    run.clean(action, true, on_exit)
+    run.clean(action, true, on_exit, -1)
     return false
   end
 
@@ -214,8 +214,9 @@ end
 ---@param action Action
 ---@param clean? boolean: Whether to remove action from running_actions
 ---@param callback function?: Function to call after killing
+---@param exit_code number?: Action's exit code
 ---@return boolean: whether successfully killed
-function run.clean(action, clean, callback)
+function run.clean(action, clean, callback, exit_code)
   if running_actions[action.name] == nil then
     return false
   end
@@ -225,7 +226,7 @@ function run.clean(action, clean, callback)
     running_actions[action.name] = nil
   end
   if callback ~= nil then
-    pcall(callback)
+    pcall(callback, exit_code)
   end
   return true
 end

--- a/lua/actions/window/available_actions.lua
+++ b/lua/actions/window/available_actions.lua
@@ -115,25 +115,7 @@ function window.select_action_under_cursor()
   -- [running] from the actions's row in the window
   -- (replace it with [killed])
   if executor.is_running(action.name) == true then
-    if executor.kill(name, prev_buf) ~= true then
-      return
-    end
-    --NOTE: make sure the buffer is modifiable before
-    --replacing any lines
-    pcall(vim.api.nvim_buf_set_option, outter_buf, "modifiable", true)
-    --NOTE: replace the [running] label with the [killed] label
-    local l = "> " .. string.rep(" ", 37) .. "[killed]"
-    pcall(
-      vim.api.nvim_buf_set_lines,
-      outter_buf,
-      linenr + 3,
-      linenr + 4,
-      false,
-      { l }
-    )
-    --NOTE: set the buffer back to not modifiable, so the
-    --user cannot change the text in the outter buffer
-    pcall(vim.api.nvim_buf_set_option, outter_buf, "modifiable", false)
+    executor.kill(name, prev_buf)
     return
   end
   --NOTE: the action was not yet running, so we may start it.
@@ -347,6 +329,8 @@ set_window_options = function()
     end,
     once = true,
   })
+  --NOTE: <Esc> closes the window by triggering
+  --the BufLeave autocmd for the actions buffer
   vim.api.nvim_buf_set_keymap(
     buf,
     "n",
@@ -358,6 +342,9 @@ set_window_options = function()
       noremap = true,
     }
   )
+  --NOTE: select the action under the cursor with <Enter>
+  --if the action is running this will kill it, otherwise
+  --it will kill it
   vim.api.nvim_buf_set_keymap(
     buf,
     "",
@@ -366,20 +353,15 @@ set_window_options = function()
       .. ".select_action_under_cursor()<CR>",
     {}
   )
+  --NOTE: show the output of an action with 'o' (if there is any)
+  --this will close the actions window and oppen
+  --the output in the current window
   vim.api.nvim_buf_set_keymap(
     buf,
     "",
     "o",
     "<CMD>lua require('actions.window.available_actions')"
       .. ".output_of_action_under_cursor()<CR>",
-    {}
-  )
-  vim.api.nvim_buf_set_keymap(
-    buf,
-    "",
-    "<CR>",
-    "<CMD>lua require('actions.window.available_actions')"
-      .. ".select_action_under_cursor()<CR>",
     {}
   )
 end

--- a/lua/actions/window/available_actions.lua
+++ b/lua/actions/window/available_actions.lua
@@ -215,6 +215,13 @@ set_outter_window_lines = function(width, actions)
     local l = "> "
     if executor.is_running(action.name) then
       l = l .. string.rep(" ", 37) .. "[running]"
+    else
+      local path = action:get_output_path()
+      print(path)
+      local ok, v = pcall(vim.fn.filereadable, path)
+      if ok == true and v == 1 then
+        l = l .. string.rep(" ", 37) .. "[output]"
+      end
     end
     table.insert(lines, l)
   end


### PR DESCRIPTION
- When oppening the available actions window, actions with an existing output file have `[output]` label.
- When action finishes, label `[running]` is replace with either:
   - `[success]` : action exited with code 0
   - `[exit]`: action exited with code > 0
   - `[error]`: error occured while running the job (in execution of the job, not in the program itself)
   - `[done]`: default