### PR TITLE
Fix blocking insert mode on a running action

### DIFF
--- a/lua/actions/executor/run_action.lua
+++ b/lua/actions/executor/run_action.lua
@@ -88,14 +88,21 @@ function run.run(action, on_exit)
     vim.api.nvim_buf_set_option(term_buf, "modifiable", true)
   end
 
+  vim.api.nvim_clear_autocmds {
+    event = { "TermClose", "TermEnter" },
+    buffer = term_buf,
+    group = "ActionsNvim",
+  }
   --NOTE: set the autocmd for the terminal buffer, so that
   --when it finishes, we cannot enter the insert mode.
   --(when we enter insert mode in the closed terminal, it is deleted)
   vim.api.nvim_create_autocmd("TermClose", {
     buffer = term_buf,
+    group = "ActionsNvim",
     callback = function()
       vim.cmd "stopinsert"
       vim.api.nvim_create_autocmd("TermEnter", {
+        group = "ActionsNvim",
         callback = function()
           vim.cmd "stopinsert"
         end,
@@ -140,7 +147,7 @@ function run.run(action, on_exit)
     if i > 0 then
       name = name .. "_" .. i
     end
-    ok, _ = pcall(vim.api.nvim_buf_set_name, term_buf, name)
+    local ok, _ = pcall(vim.api.nvim_buf_set_name, term_buf, name)
     if ok == true then
       break
     end
@@ -153,7 +160,7 @@ function run.run(action, on_exit)
   vim.api.nvim_buf_set_option(term_buf, "bufhidden", "hide")
   vim.api.nvim_buf_set_option(term_buf, "modifiable", false)
   vim.api.nvim_buf_set_option(term_buf, "modified", false)
-  vim.api.nvim_buf_set_option(term_buf, "filetype", "action_output")
+  vim.api.nvim_buf_set_option(term_buf, "filetype", "action_output_terminal")
 
   running_actions[action.name] = {
     job = job_id,

--- a/lua/actions/window/action_output.lua
+++ b/lua/actions/window/action_output.lua
@@ -28,7 +28,7 @@ function window.open(action)
   --NOTE: execute the BufLeave autocmds, so the
   --available actions window is wiped
   vim.api.nvim_exec_autocmds("BufLeave", {
-    group = "ActionsWindow",
+    group = "ActionsNvim",
   })
 
   --NOTE: if the action already has a window oppened for

--- a/lua/actions/window/available_actions.lua
+++ b/lua/actions/window/available_actions.lua
@@ -357,12 +357,13 @@ set_window_options = function()
   vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
   vim.api.nvim_buf_set_option(outter_buf, "bufhidden", "wipe")
 
-  vim.api.nvim_create_augroup("ActionsWindow", {
-    clear = true,
-  })
+  vim.api.nvim_clear_autocmds {
+    event = "BufLeave",
+    group = "ActionsNvim",
+  }
   vim.api.nvim_create_autocmd("BufLeave", {
     buffer = buf,
-    group = "ActionsWindow",
+    group = "ActionsNvim",
     callback = function()
       vim.api.nvim_buf_delete(buf, {
         force = true,
@@ -381,7 +382,7 @@ set_window_options = function()
     "<Esc>",
     "<CMD>call nvim_exec_autocmds('BufLeave', {'buffer':"
       .. buf
-      .. ", 'group':'ActionsWindow'})<CR>",
+      .. ", 'group':'ActionsNvim'})<CR>",
     {
       noremap = true,
     }

--- a/plugin/actions.lua
+++ b/plugin/actions.lua
@@ -10,3 +10,5 @@ if vim.g.loaded_actions_nvim == 1 then
   return
 end
 vim.g.loaded_actions_nvim = 1
+
+vim.api.nvim_create_augroup("ActionsNvim", { clear = true })


### PR DESCRIPTION
- When an action had been restarted, the terminal insert mode was still being blocked from the previous autocmd.
  - Now the previous autocmds are cleared when restarting the action
  - All autocmds now belong to same augroup: `ActionsNvim`
  
- Changed filetype of output buffer to `actions_output_terminal`