### PR TITLE
Bugfix/no actions from output buffer

### DIFF
--- a/lua/actions/enum.lua
+++ b/lua/actions/enum.lua
@@ -1,0 +1,6 @@
+local enum = {}
+
+enum.OUTPUT_BUFFER_FILETYPE = "actions_output_terminal"
+enum.ACTIONS_AUGROUP = "ActionsNvim"
+
+return enum

--- a/lua/actions/executor/run_action.lua
+++ b/lua/actions/executor/run_action.lua
@@ -1,4 +1,5 @@
 local log = require "actions.log"
+local enum = require "actions.enum"
 
 ---A table with actions' names as keys
 ---and their job ids as values
@@ -91,18 +92,18 @@ function run.run(action, on_exit)
   vim.api.nvim_clear_autocmds {
     event = { "TermClose", "TermEnter" },
     buffer = term_buf,
-    group = "ActionsNvim",
+    group = enum.ACTIONS_AUGROUP,
   }
   --NOTE: set the autocmd for the terminal buffer, so that
   --when it finishes, we cannot enter the insert mode.
   --(when we enter insert mode in the closed terminal, it is deleted)
   vim.api.nvim_create_autocmd("TermClose", {
     buffer = term_buf,
-    group = "ActionsNvim",
+    group = enum.ACTIONS_AUGROUP,
     callback = function()
       vim.cmd "stopinsert"
       vim.api.nvim_create_autocmd("TermEnter", {
-        group = "ActionsNvim",
+        group = enum.ACTIONS_AUGROUP,
         callback = function()
           vim.cmd "stopinsert"
         end,
@@ -160,7 +161,11 @@ function run.run(action, on_exit)
   vim.api.nvim_buf_set_option(term_buf, "bufhidden", "hide")
   vim.api.nvim_buf_set_option(term_buf, "modifiable", false)
   vim.api.nvim_buf_set_option(term_buf, "modified", false)
-  vim.api.nvim_buf_set_option(term_buf, "filetype", "action_output_terminal")
+  vim.api.nvim_buf_set_option(
+    term_buf,
+    "filetype",
+    enum.OUTPUT_BUFFER_FILETYPE
+  )
 
   running_actions[action.name] = {
     job = job_id,

--- a/lua/actions/window/action_output.lua
+++ b/lua/actions/window/action_output.lua
@@ -1,5 +1,6 @@
 local setup = require "actions.setup"
 local log = require "actions.log"
+local enum = require "actions.enum"
 local run_action = require "actions.executor.run_action"
 
 local oppened_win = nil
@@ -28,7 +29,7 @@ function window.open(action)
   --NOTE: execute the BufLeave autocmds, so the
   --available actions window is wiped
   vim.api.nvim_exec_autocmds("BufLeave", {
-    group = "ActionsNvim",
+    group = enum.ACTIONS_AUGROUP,
   })
 
   --NOTE: if the action already has a window oppened for

--- a/lua/actions/window/available_actions.lua
+++ b/lua/actions/window/available_actions.lua
@@ -2,6 +2,7 @@ local log = require "actions.log"
 local setup = require "actions.setup"
 local executor = require "actions.executor"
 local output_window = require "actions.window.action_output"
+local enum = require "actions.enum"
 
 local window = {}
 
@@ -31,7 +32,8 @@ function window.open()
   local cur_buf = vim.fn.bufnr()
   if
     vim.api.nvim_buf_get_option(cur_buf, "buftype") ~= "terminal"
-    or vim.api.nvim_buf_get_option(cur_buf, "filetype") ~= "action_output"
+    or vim.api.nvim_buf_get_option(cur_buf, "filetype")
+      ~= enum.OUTPUT_BUFFER_FILETYPE
   then
     prev_buf = vim.fn.bufnr()
   end
@@ -359,11 +361,11 @@ set_window_options = function()
 
   vim.api.nvim_clear_autocmds {
     event = "BufLeave",
-    group = "ActionsNvim",
+    group = enum.ACTIONS_AUGROUP,
   }
   vim.api.nvim_create_autocmd("BufLeave", {
     buffer = buf,
-    group = "ActionsNvim",
+    group = enum.ACTIONS_AUGROUP,
     callback = function()
       vim.api.nvim_buf_delete(buf, {
         force = true,
@@ -382,7 +384,9 @@ set_window_options = function()
     "<Esc>",
     "<CMD>call nvim_exec_autocmds('BufLeave', {'buffer':"
       .. buf
-      .. ", 'group':'ActionsNvim'})<CR>",
+      .. ", 'group':'"
+      .. enum.ACTIONS_AUGROUP
+      .. "'})<CR>",
     {
       noremap = true,
     }

--- a/plugin/actions.lua
+++ b/plugin/actions.lua
@@ -11,4 +11,7 @@ if vim.g.loaded_actions_nvim == 1 then
 end
 vim.g.loaded_actions_nvim = 1
 
-vim.api.nvim_create_augroup("ActionsNvim", { clear = true })
+vim.api.nvim_create_augroup(
+  require("actions.enum").ACTIONS_AUGROUP,
+  { clear = true }
+)


### PR DESCRIPTION
Available actions window was checking for invalid filetype, as it had been changed to `actions_output_terminal`.
Now such values are in an enum, and the same values are used across all files.