### PR TITLE
Feature/wrap text in output

### DIFF
--- a/lua/actions/executor/run_action.lua
+++ b/lua/actions/executor/run_action.lua
@@ -65,6 +65,9 @@ function run.run(action, on_exit)
   local cmd = "echo '==> ACTION: ["
     .. vim.fn.shellescape(action.name)
     .. "]\n' "
+  if cwd ~= nil then
+    cmd = cmd .. " && echo '\n==> CWD: [" .. cwd .. "]\n'"
+  end
   for _, step in ipairs(steps) do
     cmd = cmd
       .. " && "

--- a/lua/actions/executor/run_action.lua
+++ b/lua/actions/executor/run_action.lua
@@ -84,10 +84,9 @@ function run.run(action, on_exit)
       log.warn(term_buf)
       return false
     end
-  else
-    vim.api.nvim_buf_set_option(term_buf, "modified", false)
-    vim.api.nvim_buf_set_option(term_buf, "modifiable", true)
   end
+  vim.api.nvim_buf_set_option(term_buf, "modified", false)
+  vim.api.nvim_buf_set_option(term_buf, "modifiable", true)
 
   vim.api.nvim_clear_autocmds {
     event = { "TermClose", "TermEnter" },

--- a/lua/actions/window/action_output.lua
+++ b/lua/actions/window/action_output.lua
@@ -57,21 +57,25 @@ function window.open(action)
 
     --NOTE: use keepjumps to no add the output buffer
     --to the jumplist
-    vim.fn.execute("keepjumps vertical sb " .. buf)
+    vim.fn.execute "keepjumps vertical sb"
   end
-  local ow = vim.fn.bufwinid(buf)
+  local winnr = vim.fn.winnr()
+  local ow = vim.fn.win_getid(winnr)
   if ow == -1 then
-    log.warn("There is no output window for action: " .. action.name)
+    log.warn "Something went wrong"
     return
   end
   oppened_win = ow
+  vim.api.nvim_win_set_option(ow, "wrap", true)
 
   --NOTE: match some higlights in the output window
   --to distinguish the echoed step and action info from
   --the actual output
   pcall(vim.api.nvim_win_call, ow, function()
-    vim.fn.matchadd("Function", "^==> ACTION: \\[\\_.\\{-}\\]$")
-    vim.fn.matchadd("Constant", "^==> STEP: \\[\\_.\\{-}\\]$")
+    vim.fn.execute("keepjumps b " .. buf)
+
+    vim.fn.matchadd("Function", "^==> ACTION: \\[\\_.\\{-}\\n\\n")
+    vim.fn.matchadd("Constant", "^==> STEP: \\[\\_.\\{-}\\n\\n")
     vim.fn.matchadd("Statement", "^\\[Process exited .*\\]$")
     vim.fn.matchadd("Function", "^\\[Process exited 0\\]$")
 

--- a/lua/actions/window/action_output.lua
+++ b/lua/actions/window/action_output.lua
@@ -76,6 +76,7 @@ function window.open(action)
 
     vim.fn.matchadd("Function", "^==> ACTION: \\[\\_.\\{-}\\n\\n")
     vim.fn.matchadd("Constant", "^==> STEP: \\[\\_.\\{-}\\n\\n")
+    vim.fn.matchadd("Comment", "^==> CWD: \\[\\_.\\{-}\\n\\n")
     vim.fn.matchadd("Statement", "^\\[Process exited .*\\]$")
     vim.fn.matchadd("Function", "^\\[Process exited 0\\]$")
 


### PR DESCRIPTION
Wrap text in output window when oppening it (***NOTE***: this does not completely fix the issue, as text sent to the buffer before the window is oppened will not be wrapped and the overflowing text will be cut)

Update output buffer highlights so they do not depend on both oppening and closing `[` being displayed.

Send CWD to output buffer when set