### PR TITLE
Feature/no output window focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,6 @@ require("actions").setup {
     -- This function should always open a window for the provided bufnr,
     -- if this function is not defined, the default is used:
     vim.fn.execute("keepjumps vertical sb " .. bufnr)
-  end,
-  after_displaying_output = function(winnid)
-    -- Useful for setting some custom higlights or remappings for the output window
-    -- NOTE: this function is called from the output window.
   end
 }
 ```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ require("actions").setup {
     -- This function should always open a window for the provided bufnr
     -- (the number of the action's output buffer),
     -- if this function is not defined, the default is used:
-    vim.fn.execute("keepjumps vertical sb " .. bufnr)
+    local winid = vim.fn.win_getid(vim.fn.winnr())
+    vim.fn.execute("keepjumps vertical sb " .. buf, true)
+    vim.fn.win_gotoid(winid)
   end
 }
 ```

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ require("actions").setup {
     end
   },
   before_displaying_output = function(bufnr)
-    -- This is useful for oppening a window for the bufnr.
-    -- This function should always open a window for the provided bufnr,
+    -- This function should always open a window for the provided bufnr
+    -- (the number of the action's output buffer),
     -- if this function is not defined, the default is used:
     vim.fn.execute("keepjumps vertical sb " .. bufnr)
   end

--- a/lua/actions/model/user_config.lua
+++ b/lua/actions/model/user_config.lua
@@ -2,7 +2,6 @@ local Log_config = require "actions.model.log_config"
 
 ---@class User_config
 ---@field before_displaying_output function
----@field after_displaying_output function
 local User_config = {
   log = Log_config.default(),
   ---A table of actions, with actions' names as keys
@@ -57,11 +56,6 @@ function User_config.create(o)
         return cfg, "before_displaying_output should be a function!"
       end
       cfg.before_displaying_output = value
-    elseif key == "after_displaying_output" then
-      if type(value) ~= "function" then
-        return cfg, "after_displaying_output should be a function!"
-      end
-      cfg.after_displaying_output = value
     else
       return cfg, "Invalid config field: " .. key
     end

--- a/lua/actions/window/action_output.lua
+++ b/lua/actions/window/action_output.lua
@@ -87,6 +87,11 @@ function window.open(action)
     vim.fn.matchadd("Comment", "^==> CWD: \\[\\_.\\{-}\\n\\n")
     vim.fn.matchadd("Statement", "^\\[Process exited .*\\]$")
     vim.fn.matchadd("Function", "^\\[Process exited 0\\]$")
+
+    if vim.fn.winwidth(ow) < 50 and vim.o.columns >= 70 then
+      -- NOTE: make sure the output window is at least 50 columns wide
+      vim.fn.execute("vertical resize " .. 50, true)
+    end
   end)
 
   --NOTE: save which action's output has last been

--- a/lua/actions/window/action_output.lua
+++ b/lua/actions/window/action_output.lua
@@ -39,6 +39,7 @@ function window.open(action)
   if existing_buf ~= nil and vim.fn.bufexists(existing_buf) == 1 then
     local winnr = vim.fn.bufwinnr(existing_buf)
     if winnr ~= -1 then
+      -- NOTE: the output window is already opened, jump to it
       vim.fn.execute("keepjumps " .. winnr .. "wincmd w", true)
       if winnr == vim.fn.bufwinnr(vim.fn.bufnr()) then
         return
@@ -59,12 +60,17 @@ function window.open(action)
     --to the jumplist
     vim.fn.execute("keepjumps vertical sb " .. buf)
   end
+  -- NOTE: get output window's id, assert that
+  -- the window has been opened in the before_displaying_output
+  -- functions (or the default 'vertical sb' if not defined)
   local ow = vim.fn.bufwinid(buf)
   if ow == -1 then
+    -- NOTE: the output window has not been opened in the
+    -- 'before_displaying_output' function.
     log.warn(
       "A window has not been opened for the output buffer! "
         .. "Make sure that 'before_displaying_output' "
-        .. "opens a window for the buffer!"
+        .. "opens a window for the buffer."
     )
     return
   end
@@ -76,8 +82,6 @@ function window.open(action)
   --to distinguish the echoed step and action info from
   --the actual output
   pcall(vim.api.nvim_win_call, ow, function()
-    --NOTE: call this as from the oppened window!
-
     vim.fn.matchadd("Function", "^==> ACTION: \\[\\_.\\{-}\\n\\n")
     vim.fn.matchadd("Constant", "^==> STEP: \\[\\_.\\{-}\\n\\n")
     vim.fn.matchadd("Comment", "^==> CWD: \\[\\_.\\{-}\\n\\n")

--- a/lua/actions/window/action_output.lua
+++ b/lua/actions/window/action_output.lua
@@ -57,33 +57,32 @@ function window.open(action)
 
     --NOTE: use keepjumps to no add the output buffer
     --to the jumplist
-    vim.fn.execute "keepjumps vertical sb"
+    vim.fn.execute("keepjumps vertical sb " .. buf)
   end
-  local winnr = vim.fn.winnr()
-  local ow = vim.fn.win_getid(winnr)
+  local ow = vim.fn.bufwinid(buf)
   if ow == -1 then
-    log.warn "Something went wrong"
+    log.warn(
+      "A window has not been opened for the output buffer! "
+        .. "Make sure that 'before_displaying_output' "
+        .. "opens a window for the buffer!"
+    )
     return
   end
   oppened_win = ow
+  -- NOTE: set wrap for the oppened window
   vim.api.nvim_win_set_option(ow, "wrap", true)
 
   --NOTE: match some higlights in the output window
   --to distinguish the echoed step and action info from
   --the actual output
   pcall(vim.api.nvim_win_call, ow, function()
-    vim.fn.execute("keepjumps b " .. buf)
+    --NOTE: call this as from the oppened window!
 
     vim.fn.matchadd("Function", "^==> ACTION: \\[\\_.\\{-}\\n\\n")
     vim.fn.matchadd("Constant", "^==> STEP: \\[\\_.\\{-}\\n\\n")
     vim.fn.matchadd("Comment", "^==> CWD: \\[\\_.\\{-}\\n\\n")
     vim.fn.matchadd("Statement", "^\\[Process exited .*\\]$")
     vim.fn.matchadd("Function", "^\\[Process exited 0\\]$")
-
-    if setup.config.after_displaying_output ~= nil then
-      --NOTE: allow the user to
-      setup.config.after_displaying_output(oppened_win)
-    end
   end)
 
   --NOTE: save which action's output has last been

--- a/lua/actions/window/action_output.lua
+++ b/lua/actions/window/action_output.lua
@@ -41,9 +41,7 @@ function window.open(action)
     if winnr ~= -1 then
       -- NOTE: the output window is already opened, jump to it
       vim.fn.execute("keepjumps " .. winnr .. "wincmd w", true)
-      if winnr == vim.fn.bufwinnr(vim.fn.bufnr()) then
-        return
-      end
+      return
     end
   end
 
@@ -58,7 +56,9 @@ function window.open(action)
 
     --NOTE: use keepjumps to no add the output buffer
     --to the jumplist
-    vim.fn.execute("keepjumps vertical sb " .. buf)
+    local winid = vim.fn.win_getid(vim.fn.winnr())
+    vim.fn.execute("keepjumps vertical sb " .. buf, true)
+    vim.fn.win_gotoid(winid)
   end
   -- NOTE: get output window's id, assert that
   -- the window has been opened in the before_displaying_output


### PR DESCRIPTION
Do not focus output window by default (this is defined by the default `before_displaying_output` function.

