### PR TITLE
Fix not setting oppened win when showing oppened output

### DIFF
--- a/doc/actions.txt
+++ b/doc/actions.txt
@@ -30,7 +30,7 @@ actions.available_actions()                      *actions.available_actions()*
 
 
 actions.toggle_last_output()                    *actions.toggle_last_output()*
-    Reopens the last output window of the last run action, or the last oppened
+    Reopens the last output window of the last run action, or the last opened
     output buffer.
 
 

--- a/lua/actions/init.lua
+++ b/lua/actions/init.lua
@@ -41,7 +41,7 @@ function actions.available_actions()
 end
 
 ---Reopens the last output window of the last run action,
----or the last oppened output buffer.
+---or the last opened output buffer.
 function actions.toggle_last_output()
   output_window.toggle_last()
 end

--- a/lua/actions/window/action_output.lua
+++ b/lua/actions/window/action_output.lua
@@ -41,14 +41,14 @@ end
 
 ---@param action Action: the action for which the output will be shown.
 ---@return function: Function to get the output buffer number
----@return function: Function to handle the oppened window
+---@return function: Function to handle the opened window
 function window.get_init_functions(action)
   ---@return number?: An action output buffer number
   local create_buffer = function()
     return run_action.get_buf_num(action.name)
   end
   local handle_window = function(winid)
-    -- NOTE: set wrap for the oppened window
+    -- NOTE: set wrap for the opened window
     vim.api.nvim_win_set_option(winid, "wrap", true)
 
     -- NOTE: match some higlights in the output window

--- a/lua/actions/window/action_output.lua
+++ b/lua/actions/window/action_output.lua
@@ -4,9 +4,6 @@ local output_window = require "actions.window.output"
 
 local window = {}
 
----@type string|nil: Name of the last oppened action
-window.last_oppened = nil
-
 ---Open the output buffer for the provided
 ---action in the current window.
 ---

--- a/lua/actions/window/available_actions.lua
+++ b/lua/actions/window/available_actions.lua
@@ -7,11 +7,11 @@ local enum = require "actions.enum"
 local window = {}
 
 ---@type number?: The buffer from which the actions buffer
----was oppened
+---was opened
 local prev_buf = nil
----@type number?: Currently oppened actions buffer
+---@type number?: Currently opened actions buffer
 local buf = nil
----@type number?: The currently oppened
+---@type number?: The currently opened
 -- actions buffer's background buffer
 local outter_buf = nil
 
@@ -27,7 +27,7 @@ local set_outter_window_highlights
 ---Opens a floating window displayed
 ---over the center of the editor.
 ---
----@return number: the oppened buffer number, -1 on failure
+---@return number: the opened buffer number, -1 on failure
 function window.open()
   local cur_buf = vim.fn.bufnr()
   if
@@ -186,7 +186,7 @@ end
 ---Reads the name of the actions in the line under the cursor.
 ---Displays the current definition of the action in the command line.
 ---NOTE: the displayed definition may differ based on the buffer
----the actions window was oppened from, but it is the same as the one
+---the actions window was opened from, but it is the same as the one
 ---that would be used for execution.
 function window.definition_of_action_under_cursor()
   local bufnr = vim.fn.bufnr()
@@ -251,7 +251,7 @@ end
 ---the available actions.
 ---Also sets higlightings for the inserted text.
 ---NOTE: this requires the actions window to
----be the currently oppened window.
+---be the currently opened window.
 ---
 ---@param actions table: a table of available actions
 set_window_lines = function(actions)
@@ -341,7 +341,7 @@ end
 
 ---Set higlights for the actions window.
 ---NOTE: actions window should be the
----currently oppened window.
+---currently opened window.
 set_window_highlights = function()
   local bufnr = vim.fn.bufnr()
   if bufnr ~= buf then
@@ -359,7 +359,7 @@ end
 
 ---Set higlights for the outter actions window.
 ---NOTE: outter actions window should be the
----currently oppened window.
+---currently opened window.
 set_outter_window_highlights = function()
   local bufnr = vim.fn.bufnr()
   if bufnr ~= outter_buf then

--- a/lua/actions/window/output.lua
+++ b/lua/actions/window/output.lua
@@ -1,8 +1,8 @@
 local setup = require "actions.setup"
 local enum = require "actions.enum"
 
----@type number?: Window ID of the currently oppened output window
-local oppened_win = nil
+---@type number?: Window ID of the currently opened output window
+local opened_win = nil
 
 local previous_create_buffer = nil
 local previous_handle_window = nil
@@ -43,7 +43,7 @@ function window.open(create_buffer, handle_window)
     -- buffer so don't open another one.
     -- Rather just jump to it.
     vim.fn.win_gotoid(existing_winid)
-    oppened_win = existing_winid
+    opened_win = existing_winid
     return
   end
 
@@ -62,15 +62,15 @@ function window.open(create_buffer, handle_window)
     )
     return
   end
-  -- handle the oppened output window
+  -- handle the opened output window
   handle_window(ow)
 
-  -- NOTE: save the oppened window so we know when to close it
+  -- NOTE: save the opened window so we know when to close it
   -- when toggling
-  oppened_win = ow
+  opened_win = ow
 
   -- NOTE: save the provided functions to be used
-  -- when toggling the previously oppened output window
+  -- when toggling the previously opened output window
   window.set_previous(create_buffer, handle_window)
 end
 
@@ -84,15 +84,15 @@ function window.set_previous(create_buffer, handle_window)
   previous_create_buffer = create_buffer
 end
 
----Reopens the last oppened output window, if there was any.
+---Reopens the last opened output window, if there was any.
 function window.toggle_last()
-  -- NOTE: if an output window is already oppened, remove it
-  if oppened_win ~= nil and vim.api.nvim_win_is_valid(oppened_win) then
-    vim.api.nvim_win_close(oppened_win, false)
+  -- NOTE: if an output window is already opened, remove it
+  if opened_win ~= nil and vim.api.nvim_win_is_valid(opened_win) then
+    vim.api.nvim_win_close(opened_win, false)
     return
   end
 
-  -- NOTE: there is currently no oppened output window.
+  -- NOTE: there is currently no opened output window.
   -- Check if there is a previous output call and execute it
   if
     previous_create_buffer ~= nil

--- a/lua/actions/window/output.lua
+++ b/lua/actions/window/output.lua
@@ -43,6 +43,7 @@ function window.open(create_buffer, handle_window)
     -- buffer so don't open another one.
     -- Rather just jump to it.
     vim.fn.win_gotoid(existing_winid)
+    oppened_win = existing_winid
     return
   end
 


### PR DESCRIPTION
***Fixed:*** opened window was not set when opening an already opened output.
  - This was problematic when multiple actions were run and opened window was not properly set, so toggling was disabled